### PR TITLE
Add CORE-ET hackathon to events

### DIFF
--- a/apps/front/mock/home/community/data.json
+++ b/apps/front/mock/home/community/data.json
@@ -1,4 +1,12 @@
 {
+    "july": [{
+        "title": "AIFoundry + OpenHW<br/>CORE-ET Hackathon",
+        "author": "AIFoundry, OpenHW & Hugging Face",
+        "date": "Jul 6, 2026 Monday",
+        "time": "Ongoing online hackathon",
+        "location": "Virtual",
+        "href": "https://huggingface.co/AIFoundry-hackathon/hf-hackathon"
+    }],
     "february": [{
         "title": "FOSDEM fringe:<br/>AI plumbers conference",
         "author": "Tanya Dadasheva & Roman Shaposhnik",

--- a/apps/front/mock/home/community/data.json
+++ b/apps/front/mock/home/community/data.json
@@ -1,6 +1,6 @@
 {
     "july": [{
-        "title": "AIFoundry + OpenHW<br/>CORE-ET Hackathon",
+        "title": "AIFoundry + OpenHW + Hugging Face<br/>CORE-ET Hackathon",
         "author": "AIFoundry, OpenHW & Hugging Face",
         "date": "Jul 6, 2026 Monday",
         "time": "Ongoing online hackathon",


### PR DESCRIPTION
## Summary
- add the current CORE-ET hackathon to the homepage Events data
- place July first so the current event is visible by default

## Verification
- python3 -m json.tool apps/front/mock/home/community/data.json