### PR TITLE
Add CORE-ET hackathon event to deployment

### DIFF
--- a/apps/front/mock/home/community/data.json
+++ b/apps/front/mock/home/community/data.json
@@ -1,4 +1,13 @@
 {
+    "Upcoming": [
+        {
+            "title": "AIFoundry + OpenHW + Hugging Face<br/>CORE-ET Hackathon",
+            "date": "Jul 6, 2026 Monday",
+            "time": "Ongoing online hackathon",
+            "location": "Virtual",
+            "href": "https://huggingface.co/AIFoundry-hackathon/hf-hackathon"
+        }
+    ],
     "Past": [
         {
             "title": "FOSDEM&#8217;26 Fringe:<br/>AI Plumbers (Un)conference",
@@ -21,7 +30,5 @@
             "location": "San Francisco, USA",
             "href": "https://luma.com/it0fskb9"
         }
-    ],
-    "Upcoming": [
     ]
 }


### PR DESCRIPTION
## Summary

Adds the CORE-ET Hackathon event to the deployment branch community events data.

This is adapted from the `develop` commits `5062770` and `34c6257`, but uses the deployment branch event schema (`Upcoming` / `Past`) instead of the newer month-key schema on `develop`.

## Notes

- Adds the event under `Upcoming`.
- Keeps `Upcoming` first so the deployed component shows the event by default.
- Does not push to `deployment` and does not create a deployment tag.

## Validation

- `jq . apps/front/mock/home/community/data.json`
- `git diff --check`
